### PR TITLE
Absence of SendInBlue key prevents from deploying functions

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,7 +25,7 @@ try {
  **********************************************/
 import * as SQR from './modules/SQR.functions';
 import * as ReportingSync from './modules/reporting.sync.functions';
-import * as Email from './modules/email.functions';
+import * as Email from './modules/Email.functions';
 import * as SE from './modules/SE.functions';
 import * as User from './modules/User.functions';
 

--- a/functions/src/modules/Email.functions.ts
+++ b/functions/src/modules/Email.functions.ts
@@ -154,13 +154,17 @@ export const sendNotificationEmail = functions.database
   .ref('/email/notifications}')
   .onCreate(async (snapshot, context) => {
     const data = snapshot.val();
-    const templateName = snapshot.key;
+    const templateName = data.template;
 
     let id;
     if (Object.keys(emailTemplates).indexOf(templateName) > -1)
       id = emailTemplates[templateName].id;
     else {
       id = await getTemplateId(templateName);
+
+      if (id === -1)
+        throw new Error(`Template "${templateName}" was not found on SendInBlue!`);
+
       emailTemplates[templateName] = { id };
     }
 


### PR DESCRIPTION
This branch includes functions that make use of the old `email/templates` storage folder on the **main** bucket, which no longer exists..
Where should that folder be found in the new structure ?