### PR TITLE
Fix: Ctrl+click in the TE tasks table

### DIFF
--- a/frontend/src/views/TE/Tasks.vue
+++ b/frontend/src/views/TE/Tasks.vue
@@ -28,7 +28,7 @@
     >
       <!-- eslint-disable vue/no-parsing-error -->
       <template v-slot:.key="{ item }">
-        <router-link :to="getTaskLink(item)">
+        <router-link @click.native.stop :to="getTaskLink(item)">
           {{ item[".key"] }}
         </router-link>
       </template>


### PR DESCRIPTION
https://trello.com/c/O6I3MX6s/311-ctrlclick-in-the-te-tasks-table-opens-the-task-in-the-current-tab-as-well