### PR TITLE
Upgrade GitHub Actions to latest versions to fix Node 20 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       projects: ${{ steps.filter.outputs.changes }}
     steps:
       # Checkout to use filters from file
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: .github/path-filters.yml
@@ -33,9 +33,9 @@ jobs:
       run:
         working-directory: ${{ matrix.project }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ${{ matrix.project }}/package.json
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,7 +21,7 @@ jobs:
     needs: deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Create tag
         run: |
           DATE=$(date +'%Y-%m-%d')

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,8 +29,8 @@ jobs:
         env:
           SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           # Using node version from functions because it's more likely to be the freshest
           node-version-file: functions/package.json


### PR DESCRIPTION
Silences the `Node 20 is being deprecated` warning on GitHub Actions runners by upgrading:\n\n- `actions/checkout@v4` → `v7`\n- `actions/setup-node@v4` → `v6`\n- `dorny/paths-filter@v3` → `v4`\n\nThe runner default is now Node 24, and these older action versions targeting Node 20 produce deprecation warnings.